### PR TITLE
Adds more extensive annotation undo/redo feature

### DIFF
--- a/survos/core/model.py
+++ b/survos/core/model.py
@@ -3,6 +3,7 @@ from ..qt_compat import QtGui, QtCore
 
 import numpy as np
 import logging as log
+from collections import deque
 
 import os
 import glob
@@ -74,7 +75,8 @@ class DataModel(QtCore.QObject):
         self.gtradius = 1
         self.gtinterpolation = 'linear'
         self.gtselected = None
-        self.last_changes = None
+        self.last_changes = deque(maxlen=10)
+        self.redo_changes = deque(maxlen=10)
         self.growing_bbox = ['data', 1., [10, 50, 50], 0]
 
         # KDE plots

--- a/survos/plugins/annotations.py
+++ b/survos/plugins/annotations.py
@@ -324,8 +324,8 @@ class Annotations(Plugin):
         slice_x = slice(xmin, xmax+1)
 
         level = self.DM.gtselected['level']
-        self.DM.last_changes = (level, (slice_z, slice_y, slice_x),
-                                indexes, values, False)
+        self.DM.last_changes.append((level, (slice_z, slice_y, slice_x),
+                                indexes, values, False))
         self.LM.update()
 
     def on_add_level(self, idx, ds):
@@ -710,7 +710,7 @@ class Annotations(Plugin):
 
             slices = slice(None), slice(None), slice(None)
             indexes = np.column_stack(np.where(mcurrent))
-            self.DM.last_changes = (dataset, slices, indexes, label)
+            self.DM.last_changes.append((dataset, slices, indexes, label))
 
         self.LBLM.setLabelParent(level, label, parent_level, parent_label)
         self.launcher.cleanup()

--- a/survos/widgets/mainwindow.py
+++ b/survos/widgets/mainwindow.py
@@ -194,20 +194,36 @@ class MainWindow(QtWidgets.QMainWindow):
                 event.key() == QtCore.Qt.Key_Z:
             # CTRL + Z
             log.debug('* DEBUG: CTRL+Z clicked')
-            if self.DM.last_changes is not None:
-                ds, slices, indexes, values, active_roi = self.DM.last_changes
-                slice_z, slice_y, slice_x = slices
+            self.undo_redo_changes(self.DM.last_changes, self.DM.redo_changes)
+        elif modifiers == (QtCore.Qt.ControlModifier | QtCore.Qt.ShiftModifier) \
+                and event.key() == QtCore.Qt.Key_Z:
+            # CTRL + shift + Z
+            log.debug('* DEBUG: CTRL+SHIFT+Z clicked')
+            self.undo_redo_changes(self.DM.redo_changes, self.DM.last_changes)
 
-                hdata = self.DM.load_slices(ds, slice_z, slice_y, slice_x,
-                                            apply_roi=active_roi)
-                prev_values = hdata[indexes[:, 0], indexes[:, 1], indexes[:, 2]]
-                hdata[indexes[:, 0], indexes[:, 1], indexes[:, 2]] = values
-                self.DM.write_slices(ds, hdata, slice_z, slice_y, slice_x,
-                                     apply_roi=active_roi)
-                self.DM.last_changes = (ds, (slice_z, slice_y, slice_x),
-                                        indexes, prev_values, active_roi)
-                self.LM.update()
-                log.info('+ Done')
+    def undo_redo_changes(self, source, destination):
+        """
+        Reapplies previous annotation changes to enable undo/redo functionality 
+
+        :param source: The source queue for changes to be applied
+        :param destination: The destination queue for the current state
+        """
+        if source:
+            ds, slices, indexes, values, active_roi = source.pop()
+            slice_z, slice_y, slice_x = slices
+
+            hdata = self.DM.load_slices(ds, slice_z, slice_y, slice_x,
+                                        apply_roi=active_roi)
+            prev_values = hdata[indexes[:, 0], indexes[:, 1], indexes[:, 2]]
+            hdata[indexes[:, 0], indexes[:, 1], indexes[:, 2]] = values
+            self.DM.write_slices(ds, hdata, slice_z, slice_y, slice_x,
+                                 apply_roi=active_roi)
+            destination.append((ds, (slice_z, slice_y, slice_x),
+                                         indexes, prev_values, active_roi))
+            self.LM.update()
+            log.info('+ Done')
+        else:
+            log.info('+ No changes in history to apply!')
 
     def mousePressEvent(self, event):
         self.setFocus()

--- a/survos/widgets/slice_viewer.py
+++ b/survos/widgets/slice_viewer.py
@@ -407,7 +407,7 @@ class LayeredCanvas(PerspectiveCanvas):
         level = self.DM.gtselected['level']
         label = self.DM.gtselected['label']
         data = self.DM.gtselected['data']
-        self.DM.last_changes = (level, label, indexes, values)
+        self.DM.last_changes.append((level, label, indexes, values))
         self.LM.update()
 
     def update_gt(self, ev):
@@ -586,8 +586,8 @@ class LayeredCanvas(PerspectiveCanvas):
         values = hdata[indexes[:, 0], indexes[:, 1], indexes[:, 2]]
         hdata[indexes[:, 0], indexes[:, 1], indexes[:, 2]] = label
         self.DM.write_slices(level, hdata, slice_z, slice_y, slice_x, apply_roi=apply_roi)
-        self.DM.last_changes = (level, (slice_z, slice_y, slice_x),
-                                indexes, values, apply_roi)
+        self.DM.last_changes.append((level, (slice_z, slice_y, slice_x),
+                                indexes, values, apply_roi))
 
         print("Time Replace Data:", time.time() - t0)
 


### PR DESCRIPTION
- Up to 10 previous annotation changes are stored for Cntrl + Z undo
- Cntrl + Shift + Z functionality added for redo
Closes #75 